### PR TITLE
Remove recent posts from sidebar

### DIFF
--- a/src/components/Sidebar.svelte
+++ b/src/components/Sidebar.svelte
@@ -40,11 +40,5 @@
 		<div class="divider" />
 
 		<Search class="mb-4" />
-
-		<div>
-			<!-- TODO: Recent activities (posts, tags, etc.) -->
-			<h2 class="text-lg font-semibold">Recent Posts</h2>
-			<p class="mt-1 text-base font-light">There is no post yet.</p>
-		</div>
 	</aside>
 </div>


### PR DESCRIPTION
Posts are listed in recent order already, at blog index page.

Resolves #23.