### PR TITLE
Fix blog post page scroll spy collision during smooth scrolling

### DIFF
--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -5,7 +5,7 @@
 	import SeriesWidget from '$components/content/SeriesWidget.svelte';
 	import { format, formatDistanceStrict } from 'date-fns';
 	import { tick } from 'svelte';
-	import { replaceState } from '$app/navigation';
+
 	let { data } = $props();
 	const { metadata, content, seriesPosts } = $derived.by(() => {
 		return data;
@@ -37,6 +37,15 @@
 			console.debug('Footnote label not found. Skipping patching.');
 		}
 	});
+
+	/**
+	 * Use native browser history replaceState instead of SvelteKit's replaceState to avoid unwanted
+	 * scrolling when updating the URL hash for the Table of Contents during scroll.
+	 * @param url - The URL or hash to set.
+	 */
+	function replaceStateBrowser(url: string) {
+		history.replaceState(null, '', url);
+	}
 
 	$effect(() => {
 		if (!contentIsReady || !contentWrapper) {
@@ -153,7 +162,7 @@
 			isInitialScroll = false;
 
 			if (nextHash !== activeId) {
-				replaceState(nextHash || window.location.pathname + window.location.search, {});
+				replaceStateBrowser(nextHash || window.location.pathname + window.location.search);
 				activeId = nextHash;
 			}
 		};
@@ -184,7 +193,7 @@
 					}, 1500); // 1.5s fallback in case scrollend doesn't fire
 
 					activeId = href;
-					replaceState(href, {});
+					replaceStateBrowser(href);
 					element.scrollIntoView({ behavior: 'smooth' });
 				}
 			}

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -46,7 +46,7 @@
 		const initialHash = window.location.hash;
 		let isInitialScroll = !!initialHash;
 		let isManualScrolling = false;
-		let scrollTimeout: NodeJS.Timeout | undefined;
+		let scrollTimeout: ReturnType<typeof setTimeout> | undefined;
 
 		// Scroll to element if hash is present in URL on mount
 		tick().then(() => {

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -45,6 +45,8 @@
 
 		const initialHash = window.location.hash;
 		let isInitialScroll = !!initialHash;
+		let isManualScrolling = false;
+		let scrollTimeout: NodeJS.Timeout | undefined;
 
 		// Scroll to element if hash is present in URL on mount
 		tick().then(() => {
@@ -117,6 +119,7 @@
 		});
 
 		const handleScroll = () => {
+			if (isManualScrolling) return;
 			if (!contentWrapper) return;
 			const headings = [
 				...contentWrapper.querySelectorAll('h1, h2, h3, h4, h5, h6')
@@ -155,13 +158,50 @@
 			}
 		};
 
+		const handleScrollEnd = () => {
+			isManualScrolling = false;
+			if (scrollTimeout) {
+				clearTimeout(scrollTimeout);
+				scrollTimeout = undefined;
+			}
+		};
+
+		const handleAnchorClick = (e: MouseEvent) => {
+			const target = e.target as HTMLElement;
+			const anchor = target.closest('a');
+			if (!anchor) return;
+
+			const href = anchor.getAttribute('href');
+			if (href && href.startsWith('#')) {
+				e.preventDefault();
+				const id = decodeURIComponent(href.slice(1));
+				const element = document.getElementById(id);
+				if (element) {
+					isManualScrolling = true;
+					if (scrollTimeout) clearTimeout(scrollTimeout);
+					scrollTimeout = setTimeout(() => {
+						isManualScrolling = false;
+					}, 1500); // 1.5s fallback in case scrollend doesn't fire
+
+					activeId = href;
+					replaceState(href, {});
+					element.scrollIntoView({ behavior: 'smooth' });
+				}
+			}
+		};
+
 		// Run once initially to set the active section based on starting scroll position
 		handleScroll();
 
 		window.addEventListener('scroll', handleScroll, { passive: true });
+		window.addEventListener('scrollend', handleScrollEnd, { passive: true });
+		window.addEventListener('click', handleAnchorClick);
 
 		return () => {
 			window.removeEventListener('scroll', handleScroll);
+			window.removeEventListener('scrollend', handleScrollEnd);
+			window.removeEventListener('click', handleAnchorClick);
+			if (scrollTimeout) clearTimeout(scrollTimeout);
 		};
 	});
 </script>


### PR DESCRIPTION
Avoid scroll spy calculations and hash replacement while smooth scrolling to a heading section is programmatically occurring.

Fixes #297

---
*PR created automatically by Jules for task [16470676564394039751](https://jules.google.com/task/16470676564394039751) started by @lasuillard*