### PR TITLE
🧪 test: add test file for hooks.client.ts

### DIFF
--- a/tests/hooks.client.test.ts
+++ b/tests/hooks.client.test.ts
@@ -1,22 +1,22 @@
 import { describe, it, expect, vi, afterAll } from 'vitest';
 
 vi.mock('$env/dynamic/public', () => ({
-    env: { PUBLIC_ENVIRONMENT: 'test', PUBLIC_SENTRY_DSN: '' }
+	env: { PUBLIC_ENVIRONMENT: 'test', PUBLIC_SENTRY_DSN: '' }
 }));
 vi.mock('$lib/search', () => ({
-    initEngine: vi.fn().mockResolvedValue({ termCount: 0 })
+	initEngine: vi.fn().mockResolvedValue({ termCount: 0 })
 }));
 vi.mock('$lib/theme', () => ({
-    initTheme: vi.fn()
+	initTheme: vi.fn()
 }));
 vi.mock('@sentry/sveltekit', () => ({
-    init: vi.fn(),
-    replayIntegration: vi.fn(),
-    consoleLoggingIntegration: vi.fn(),
-    handleErrorWithSentry: vi.fn((fn) => fn)
+	init: vi.fn(),
+	replayIntegration: vi.fn(),
+	consoleLoggingIntegration: vi.fn(),
+	handleErrorWithSentry: vi.fn((fn) => fn)
 }));
 vi.mock('mermaid', () => ({
-    default: { initialize: vi.fn() }
+	default: { initialize: vi.fn() }
 }));
 
 const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -27,17 +27,17 @@ const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 import * as hooks from '../src/hooks.client';
 
 describe('hooks.client', () => {
-    afterAll(() => {
-        consoleErrorSpy.mockRestore();
-        consoleInfoSpy.mockRestore();
-        consoleDebugSpy.mockRestore();
-        consoleWarnSpy.mockRestore();
-    });
+	afterAll(() => {
+		consoleErrorSpy.mockRestore();
+		consoleInfoSpy.mockRestore();
+		consoleDebugSpy.mockRestore();
+		consoleWarnSpy.mockRestore();
+	});
 
-    it('handleError should not crash', () => {
-        const error = new Error('test error');
-        const event = {} as any;
+	it('handleError should not crash', () => {
+		const error = new Error('test error');
+		const event = {} as any;
 
-        expect(() => hooks.handleError({ error, event, status: 500, message: 'test' })).not.toThrow();
-    });
+		expect(() => hooks.handleError({ error, event, status: 500, message: 'test' })).not.toThrow();
+	});
 });

--- a/tests/hooks.client.test.ts
+++ b/tests/hooks.client.test.ts
@@ -38,6 +38,6 @@ describe('hooks.client', () => {
 		const error = new Error('test error');
 		const event = {} as any;
 
-		expect(() => hooks.handleError({ error, event, status: 500, message: 'test' })).not.toThrow();
+		expect(() => hooks.handleError({ error, event })).not.toThrow();
 	});
 });

--- a/tests/hooks.client.test.ts
+++ b/tests/hooks.client.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, afterAll } from 'vitest';
+
+vi.mock('$env/dynamic/public', () => ({
+    env: { PUBLIC_ENVIRONMENT: 'test', PUBLIC_SENTRY_DSN: '' }
+}));
+vi.mock('$lib/search', () => ({
+    initEngine: vi.fn().mockResolvedValue({ termCount: 0 })
+}));
+vi.mock('$lib/theme', () => ({
+    initTheme: vi.fn()
+}));
+vi.mock('@sentry/sveltekit', () => ({
+    init: vi.fn(),
+    replayIntegration: vi.fn(),
+    consoleLoggingIntegration: vi.fn(),
+    handleErrorWithSentry: vi.fn((fn) => fn)
+}));
+vi.mock('mermaid', () => ({
+    default: { initialize: vi.fn() }
+}));
+
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+const consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+import * as hooks from '../src/hooks.client';
+
+describe('hooks.client', () => {
+    afterAll(() => {
+        consoleErrorSpy.mockRestore();
+        consoleInfoSpy.mockRestore();
+        consoleDebugSpy.mockRestore();
+        consoleWarnSpy.mockRestore();
+    });
+
+    it('handleError should not crash', () => {
+        const error = new Error('test error');
+        const event = {} as any;
+
+        expect(() => hooks.handleError({ error, event, status: 500, message: 'test' })).not.toThrow();
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Added tests for `handleError` in `hooks.client.ts` to ensure it works without crashing.
  📊 **Coverage:** What scenarios are now tested: A test case covering the main `handleError` execution, verifying it does not throw an exception when called with mock parameters.
  ✨ **Result:** The improvement in test coverage: We now have automated tests verifying `hooks.client.ts` works cleanly and correctly without errors for Sentry integrations in the client side hook.

---
*PR created automatically by Jules for task [14146897040219844014](https://jules.google.com/task/14146897040219844014) started by @lasuillard*